### PR TITLE
workflow: Add CI configuration for build and testing

### DIFF
--- a/ci.yml
+++ b/ci.yml
@@ -1,0 +1,46 @@
+name: Build CI
+
+on:
+  push:
+    branches: [ "main", "dev**" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+
+    services:
+      redis:
+        image: redis:7
+        ports:
+          - 6379:6379
+        options: >-
+          --health-cmd "redis-cli ping"
+          --health-interval 10s
+          --health-timeout 5s
+          --health-retries 5
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          java-version: '17'
+          distribution: 'temurin'
+          cache: 'maven'
+
+      - name: Make Maven Wrapper executable
+        run: chmod +x ./mvnw
+
+      - name: Build and Test
+        run: ./mvnw -B clean package
+
+      - name: Upload build artifact
+        uses: actions/upload-artifact@v4
+        with:
+          name: MioVerify-${{ github.sha }}
+          path: target/MioVerify-*.jar
+          retention-days: 30


### PR DESCRIPTION
This CI configuration sets up a build process using JDK 17 and Redis service, including steps for checking out the repository, making the Maven wrapper executable, building the project, and uploading the build artifact.